### PR TITLE
Fix invalid links for generated documents

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -159,14 +159,14 @@ http {
             # Добавляем логирование для отладки
             access_log /var/log/nginx/documents_access.log main;
             error_log /var/log/nginx/documents_error.log debug;
-            
-            # MinIO ожидает путь без префикса generated-documents, поэтому убираем его
-            proxy_pass http://minio_api/documents/$1$is_args$args;
+
+            # Передаем запрос в MinIO без изменения пути
+            proxy_pass http://minio_api;
             proxy_set_header Host minio:9000;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            
+
             # Важно: передаем query параметры (подпись)
             proxy_pass_request_headers on;
             add_header Cache-Control "no-cache";


### PR DESCRIPTION
## Summary
- fix nginx proxy path for generated documents

## Testing
- `pytest -q`