### PR TITLE
Add pdf combine and asset name checks

### DIFF
--- a/backend/apps/templates/migrations/0003_asset_unique_name.py
+++ b/backend/apps/templates/migrations/0003_asset_unique_name.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('templates', '0002_initial'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='asset',
+            unique_together={('template', 'name')},
+        ),
+    ]
+

--- a/backend/apps/templates/models/template.py
+++ b/backend/apps/templates/models/template.py
@@ -304,6 +304,7 @@ class Asset(BaseModel):
         verbose_name = "Ассет"
         verbose_name_plural = "Ассеты"
         ordering = ['template', 'name']
+        unique_together = ['template', 'name']
     
     def __str__(self):
         if self.page:

--- a/backend/apps/templates/services/asset_helper.py
+++ b/backend/apps/templates/services/asset_helper.py
@@ -47,6 +47,21 @@ class AssetHelper(FileHelper):
             template = Template.objects.get(id=template_id)
         except Template.DoesNotExist:
             raise ValueError(f"Template not found: {template_id}")
+
+        if not filename:
+            if isinstance(file_obj, (str, Path)):
+                filename = Path(file_obj).name
+            elif hasattr(file_obj, 'name'):
+                filename = Path(file_obj.name).name
+            else:
+                raise ValueError("Filename is required")
+
+        # Проверяем уникальность имени
+        if Asset.objects.filter(template=template, name=filename).exists():
+            import uuid
+            stem = Path(filename).stem
+            suffix = Path(filename).suffix
+            filename = f"{stem}_{uuid.uuid4().hex[:8]}{suffix}"
         
         # Подготавливаем файловый объект и получаем его размер
         if isinstance(file_obj, (str, Path)):

--- a/pdf-renderer/Controllers/PdfController.cs
+++ b/pdf-renderer/Controllers/PdfController.cs
@@ -4,6 +4,9 @@ using PdfRenderer.Services;
 using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 namespace PdfRenderer.Controllers;
 
@@ -68,13 +71,41 @@ public class PdfController : ControllerBase
             
             return File(pdfData, "application/pdf", $"document_{DateTime.Now:yyyyMMddHHmmss}.pdf");
         }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning(ex, "PDF contains more than one page");
+            return BadRequest(new { error = ex.Message });
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error during PDF generation");
-            return StatusCode(500, new { 
-                error = "Internal server error", 
-                details = ex.Message 
+            return StatusCode(500, new {
+                error = "Internal server error",
+                details = ex.Message
             });
         }
     }
-} 
+
+    [HttpPost("api/combine")]
+    [Consumes("application/json")]
+    [Produces("application/pdf")]
+    public IActionResult Combine([FromBody] CombineRequest request)
+    {
+        if (request.PdfBase64 == null || request.PdfBase64.Count == 0)
+        {
+            return BadRequest(new { error = "No PDF data provided" });
+        }
+
+        try
+        {
+            var pdfBytes = request.PdfBase64.Select(b => Convert.FromBase64String(b));
+            var combined = _pdfRenderService.CombinePdfs(pdfBytes);
+            return File(combined, "application/pdf", $"combined_{DateTime.Now:yyyyMMddHHmmss}.pdf");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error combining PDFs");
+            return StatusCode(500, new { error = ex.Message });
+        }
+    }
+}

--- a/pdf-renderer/Models/CombineRequest.cs
+++ b/pdf-renderer/Models/CombineRequest.cs
@@ -1,0 +1,7 @@
+namespace PdfRenderer.Models;
+
+public class CombineRequest
+{
+    public required List<string> PdfBase64 { get; set; }
+}
+

--- a/pdf-renderer/Services/PdfRenderService.cs
+++ b/pdf-renderer/Services/PdfRenderService.cs
@@ -7,6 +7,7 @@ using iText.Kernel.Pdf;
 using iText.Kernel.Geom;
 using iText.Html2pdf.Resolver.Font;
 using iText.IO.Font.Constants;
+using iText.Kernel.Utils;
 using Microsoft.Extensions.Logging;
 using PdfRenderer.Models;
 using PdfRenderer.Utils;
@@ -25,9 +26,9 @@ public class PdfRenderService
         var options = request.Options;
         
         // Calculate page size including bleeds
-        float width = UnitConverter.ConvertToPoints(options.Width, options.Unit);
-        float height = UnitConverter.ConvertToPoints(options.Height, options.Unit);
-        float bleedPoints = UnitConverter.ConvertToPoints(options.Bleeds, options.Unit);
+        float width = UnitConverter.ConvertToPoints(options.Width, options.Unit, options.Dpi);
+        float height = UnitConverter.ConvertToPoints(options.Height, options.Unit, options.Dpi);
+        float bleedPoints = UnitConverter.ConvertToPoints(options.Bleeds, options.Unit, options.Dpi);
         
         // Add bleeds to page size
         float pageWidth = width + (bleedPoints * 2);
@@ -55,7 +56,12 @@ public class PdfRenderService
         // Render HTML to PDF
         using var htmlStream = new MemoryStream(Encoding.UTF8.GetBytes(request.Html));
         HtmlConverter.ConvertToPdf(htmlStream, pdfDocument, props);
-        
+
+        if (pdfDocument.GetNumberOfPages() != 1)
+        {
+            throw new InvalidOperationException($"Expected 1 page, got {pdfDocument.GetNumberOfPages()}");
+        }
+
         return memoryStream.ToArray();
     }
     
@@ -83,4 +89,21 @@ public class PdfRenderService
         // For now, we'll log that CMYK support is enabled
         // Full CMYK support may require additional configuration
     }
-} 
+
+    public byte[] CombinePdfs(IEnumerable<byte[]> pdfFiles)
+    {
+        using var ms = new MemoryStream();
+        using var writer = new PdfWriter(ms);
+        using var pdfDoc = new PdfDocument(writer);
+        var merger = new PdfMerger(pdfDoc);
+
+        foreach (var bytes in pdfFiles)
+        {
+            using var src = new PdfDocument(new PdfReader(new MemoryStream(bytes)));
+            merger.Merge(src, 1, src.GetNumberOfPages());
+        }
+
+        merger.Close();
+        return ms.ToArray();
+    }
+}

--- a/pdf-renderer/Utils/UnitConverter.cs
+++ b/pdf-renderer/Utils/UnitConverter.cs
@@ -11,14 +11,14 @@ namespace PdfRenderer.Utils
         /// <summary>
         /// Распознает единицы измерения и преобразует в пункты (для PDF)
         /// </summary>
-        public static float ConvertToPoints(float value, string units)
+        public static float ConvertToPoints(float value, string units, float dpi = 96)
         {
             return units.ToLower() switch
             {
                 "mm" => MillimetersToPoints(value),
                 "pt" => value,
-                "px" => PixelsToPoints(value, 96), // 96 dpi - стандартное разрешение экрана
-                _ => value, // По умолчанию считаем, что уже в пунктах
+                "px" => PixelsToPoints(value, dpi),
+                _ => value,
             };
         }
         


### PR DESCRIPTION
## Summary
- enforce asset name uniqueness
- support DPI setting in PDF renderer
- throw error if PDF has more than one page
- add PDF combine endpoint
- generate migration for asset name constraint

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `dotnet build pdf-renderer/pdf-renderer.csproj` *(fails: command not found)*