### PR TITLE
Fix PDF render service closing issue

### DIFF
--- a/pdf-renderer/README.MD
+++ b/pdf-renderer/README.MD
@@ -192,3 +192,14 @@ PDF Renderer поддерживает пользовательские шриф�
 - `ASPNETCORE_URLS`: URL для прослушивания (например, "http://+:8081")
 - `Logging__LogLevel__Default`: Уровень логирования по умолчанию
 - `Logging__LogLevel__PdfRenderer`: Уровень логирования для PdfRenderer
+
+### Требования к окружению
+
+Для сборки и локального запуска сервиса необходим установленный .NET SDK (версии 9.0 или новее). Проще всего установить его через прилагаемый скрипт `dotnet-install.sh`:
+
+```bash
+./dotnet-install.sh --version latest --install-dir $HOME/.dotnet
+export PATH="$HOME/.dotnet:$PATH"
+```
+
+Скрипт не требует прав администратора и подходит для окружений без предустановленного .NET.

--- a/pdf-renderer/Services/PdfRenderService.cs
+++ b/pdf-renderer/Services/PdfRenderService.cs
@@ -38,7 +38,8 @@ public class PdfRenderService
         _logger.LogInformation($"Page size: {pageWidth}x{pageHeight} pt (including {bleedPoints}pt bleeds)");
         
         using var memoryStream = new MemoryStream();
-        using var writer = new PdfWriter(memoryStream);
+        var writerProps = new WriterProperties().SetCloseStream(false);
+        using var writer = new PdfWriter(memoryStream, writerProps);
         using var pdfDocument = new PdfDocument(writer);
         
         // Set page size
@@ -56,13 +57,16 @@ public class PdfRenderService
         
         // Render HTML to PDF
         using var htmlStream = new MemoryStream(Encoding.UTF8.GetBytes(request.Html));
-        HtmlConverter.ConvertToPdf(htmlStream, pdfDocument, props);
+        var document = HtmlConverter.ConvertToDocument(htmlStream, pdfDocument, props);
 
         if (pdfDocument.GetNumberOfPages() != 1)
         {
+            document.Close();
             throw new InvalidOperationException($"Expected 1 page, got {pdfDocument.GetNumberOfPages()}");
         }
 
+        document.Close();
+        // Stream remains open due to WriterProperties
         return memoryStream.ToArray();
     }
     


### PR DESCRIPTION
## Summary
- prevent closing output stream in PdfRenderService by setting `WriterProperties`
- use `ConvertToDocument` to check pages before closing PDF
- document .NET install steps for the renderer

## Testing
- `dotnet build pdf-renderer/pdf-renderer.csproj -c Release` *(fails: command not found)*