### PR TITLE
Improve PDF rendering service

### DIFF
--- a/pdf-renderer/Models/RenderRequest.cs
+++ b/pdf-renderer/Models/RenderRequest.cs
@@ -14,6 +14,7 @@ public class RenderOptions
     public required string Unit { get; set; }
     public int Dpi { get; set; } = 300;
     public bool CmykSupport { get; set; } = true;
+    public string? ColorProfilePath { get; set; }
     public float Bleeds { get; set; } = 0;
     public string? BaseUri { get; set; }
 }

--- a/pdf-renderer/README.MD
+++ b/pdf-renderer/README.MD
@@ -51,6 +51,7 @@ pdf-renderer/
 - `Height`: Высота страницы
 - `Units`: Единицы измерения (px, mm)
 - `Bleeds`: Размер припусков
+- `ColorProfilePath`: путь к ICC профилю для CMYK (опционально)
 - `GeneratePreview`: Генерировать ли превью
 - `Settings`: Дополнительные настройки
 

--- a/pdf-renderer/Services/PdfRenderService.cs
+++ b/pdf-renderer/Services/PdfRenderService.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using iText.Html2pdf;
 using iText.Kernel.Pdf;
 using iText.Kernel.Geom;
-using iText.Html2pdf.Resolver.Font;
+using iText.Layout.Font;
 using iText.IO.Font.Constants;
 using iText.StyledXmlParser.Css.Validate;
 using iText.StyledXmlParser.Css.Validate.Impl;
@@ -55,7 +55,7 @@ public class PdfRenderService
         // Set CMYK support
         if (options.CmykSupport)
         {
-            EnableCmykSupport(props, pdfDocument);
+            EnableCmykSupport(props, pdfDocument, options.ColorProfilePath);
         }
         
         // Render HTML to PDF
@@ -80,12 +80,16 @@ public class PdfRenderService
         string baseUri = options.BaseUri ?? Environment.CurrentDirectory;
 
         // Font provider and assets directory
-        var fontProvider = new DefaultFontProvider(true, false, false);
-        var assetsDir = Path.Combine(baseUri, "assets");
+        var fontProvider = new FontProvider();
+        fontProvider.AddStandardPdfFonts();
+        fontProvider.AddSystemFonts();
+
+        var assetsDir = System.IO.Path.Combine(baseUri, "assets");
         if (Directory.Exists(assetsDir))
         {
             fontProvider.AddDirectory(assetsDir);
         }
+
         props.SetFontProvider(fontProvider);
 
         // Base URI for relative resources
@@ -94,11 +98,19 @@ public class PdfRenderService
         return props;
     }
     
-    private void EnableCmykSupport(ConverterProperties props, PdfDocument pdfDocument)
+    private void EnableCmykSupport(ConverterProperties props, PdfDocument pdfDocument, string? profilePath)
     {
         _logger.LogInformation("CMYK support enabled");
         // Allow device-cmyk() colors in CSS
         CssDeclarationValidationMaster.SetValidator(new CssDeviceCmykAwareValidator());
+
+        if (!string.IsNullOrEmpty(profilePath) && File.Exists(profilePath))
+        {
+            _logger.LogInformation($"Using ICC profile: {profilePath}");
+            using var profileStream = File.OpenRead(profilePath);
+            var outputIntent = new PdfOutputIntent("Custom", "", "", "CMYK", profileStream);
+            props.SetDocumentOutputIntent(outputIntent);
+        }
     }
 
     public byte[] CombinePdfs(IEnumerable<byte[]> pdfFiles)


### PR DESCRIPTION
## Summary
- enhance font handling by using `FontProvider` and adding system fonts
- allow ICC color profiles for CMYK rendering
- expose `ColorProfilePath` option in `RenderOptions`
- update documentation

## Testing
- `dotnet build pdf-renderer/pdf-renderer.csproj --no-restore`
- `dotnet run --project pdf-renderer/pdf-renderer.csproj --no-restore --urls http://localhost:8081`