### PR TITLE
Fix font handling with fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ Thumbs.db
 # Документы PDF
 backend/storage/documents/*.pdf
 backend/storage/documents/**/*.pdf
+.nuget-packages/

--- a/pdf-renderer/Services/PdfRenderService.cs
+++ b/pdf-renderer/Services/PdfRenderService.cs
@@ -8,6 +8,7 @@ using iText.Kernel.Pdf;
 using iText.Kernel.Geom;
 using iText.Layout.Font;
 using iText.IO.Font.Constants;
+using iText.Html2pdf.Resolver.Font;
 using iText.StyledXmlParser.Css.Validate;
 using iText.StyledXmlParser.Css.Validate.Impl;
 using iText.Kernel.Utils;
@@ -80,7 +81,7 @@ public class PdfRenderService
         string baseUri = options.BaseUri ?? Environment.CurrentDirectory;
 
         // Font provider and assets directory
-        var fontProvider = new FontProvider();
+        var fontProvider = new FontProvider("DejaVu Sans");
         fontProvider.AddStandardPdfFonts();
         fontProvider.AddSystemFonts();
 


### PR DESCRIPTION
## Summary
- set up `FontProvider` with standard and system fonts
- keep user-provided fonts while using DejaVu Sans as fallback for Cyrillic

## Testing
- `dotnet build pdf-renderer/pdf-renderer.csproj --no-restore`